### PR TITLE
Add Option for Label After Checkbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ purposes, pass a truthy value to the `label` property of the plugin options:
 var parser = md().use(taskLists, {label: true});
 ```
 
+To add the label after the checkbox pass a truthy value to `labelAfter` property:
+
+```js
+var parser = md().use(taskLists, {label: true, labelAfter: true});
+```
+
+**Note:** This option does require the `label` option to be truthy.
+
 The options can be combined, of course.
 
 ### Browser Usage

--- a/index.js
+++ b/index.js
@@ -62,7 +62,11 @@ function todoify(token, TokenConstructor) {
 	if (useLabelWrapper) {
 		if (useLabelAfter) {
 			token.children.pop();
-			token.children.push(afterLabel(token.content, TokenConstructor));
+
+			// Use timestamp as id property of the checkbox.
+			var id = new Date().getTime();
+			token.children[0].content = token.children[0].content.slice(0, -1) + ' id="' + id + '">';
+			token.children.push(afterLabel(token.content, id, TokenConstructor));
 		} else {
 			token.children.unshift(beginLabel(TokenConstructor));
 			token.children.push(endLabel(TokenConstructor));
@@ -95,9 +99,10 @@ function endLabel(TokenConstructor) {
 	return token;
 }
 
-function afterLabel(content, TokenConstructor) {
+function afterLabel(content, id, TokenConstructor) {
 	var token = new TokenConstructor('html_inline', '', 0);
-	token.content = '<label>' + content + '</label>';
+	token.content = '<label for="' + id + '">' + content + '</label>';
+	token.attrs = [{for: id}];
 	return token;
 }
 

--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ function todoify(token, TokenConstructor) {
 			token.children.pop();
 
 			// Use large random number as id property of the checkbox.
-			var id = Math.ceil(Math.random() * (10000 * 1000) - 1000);
+			var id = 'task-item-' + Math.ceil(Math.random() * (10000 * 1000) - 1000);
 			token.children[0].content = token.children[0].content.slice(0, -1) + ' id="' + id + '">';
 			token.children.push(afterLabel(token.content, id, TokenConstructor));
 		} else {

--- a/index.js
+++ b/index.js
@@ -5,11 +5,13 @@
 
 var disableCheckboxes = true;
 var useLabelWrapper = false;
+var useLabelAfter = false;
 
 module.exports = function(md, options) {
 	if (options) {
 		disableCheckboxes = !options.enabled;
 		useLabelWrapper = !!options.label;
+		useLabelAfter = !!options.labelAfter;
 	}
 
 	md.core.ruler.after('inline', 'github-task-lists', function(state) {
@@ -58,8 +60,13 @@ function todoify(token, TokenConstructor) {
 	token.content = token.content.slice(3);
 
 	if (useLabelWrapper) {
-		token.children.unshift(beginLabel(TokenConstructor));
-		token.children.push(endLabel(TokenConstructor));
+		if (useLabelAfter) {
+			token.children.pop();
+			token.children.push(afterLabel(token.content, TokenConstructor));
+		} else {
+			token.children.unshift(beginLabel(TokenConstructor));
+			token.children.push(endLabel(TokenConstructor));
+		}
 	}
 }
 
@@ -85,6 +92,12 @@ function beginLabel(TokenConstructor) {
 function endLabel(TokenConstructor) {
 	var token = new TokenConstructor('html_inline', '', 0);
 	token.content = '</label>';
+	return token;
+}
+
+function afterLabel(content, TokenConstructor) {
+	var token = new TokenConstructor('html_inline', '', 0);
+	token.content = '<label>' + content + '</label>';
 	return token;
 }
 

--- a/index.js
+++ b/index.js
@@ -63,8 +63,8 @@ function todoify(token, TokenConstructor) {
 		if (useLabelAfter) {
 			token.children.pop();
 
-			// Use timestamp as id property of the checkbox.
-			var id = new Date().getTime();
+			// Use large random number as id property of the checkbox.
+			var id = Math.ceil(Math.random() * (10000 * 1000) - 1000);
 			token.children[0].content = token.children[0].content.slice(0, -1) + ' id="' + id + '">';
 			token.children.push(afterLabel(token.content, id, TokenConstructor));
 		} else {
@@ -101,7 +101,7 @@ function endLabel(TokenConstructor) {
 
 function afterLabel(content, id, TokenConstructor) {
 	var token = new TokenConstructor('html_inline', '', 0);
-	token.content = '<label for="' + id + '">' + content + '</label>';
+	token.content = '<label class="task-list-item-label" for="' + id + '">' + content + '</label>';
 	token.attrs = [{for: id}];
 	return token;
 }

--- a/test/index.js
+++ b/test/index.js
@@ -87,6 +87,12 @@ describe('markdown-it-task-lists', function() {
         assert($$('.task-list-item > label > input[type=checkbox].task-list-item-checkbox:not([disabled])').length > 0);
     });
 
+    it('adds label after items when options.label and options.labelAfter are truthy', function() {
+      var enabledLabeledParser = md().use(taskLists, {enabled: true, label: true, labelAfter: true});
+      var $$ = cheerio.load(enabledLabeledParser.render(fixtures.ordered));
+      assert( $$('.task-list-item > input[type=checkbox].task-list-item-checkbox:not([disabled])').next().is('label'));
+    });
+
     it('does NOT render [  ], "[ ]" (no space after closing bracket), [ x], [x ], or [ x ] as checkboxes', function () {
         var html = $.dirty.html();
         assert(~html.indexOf('<li>[  ]'));


### PR DESCRIPTION
Hello,

I like your markdown-it plugin and wanted to style the label and checkbox using CSS similar to [this example](https://codepen.io/Vestride/pen/dABHx).  The problem I've run into with these styles, and others, is that they assume the label element is after the checkbox.

So I whipped up a **labelAfter** option and simple function that places the label after checkbox after adding an **id** property and a **for** property.  I used a timestamp for uniqueness.

Also, added a test for the label after to make sure I didn't break anything else.  If you'd like the code to cleaned up, adjusted, etc please let me know.

Thanks,
Adam