### PR TITLE
Also remove first space from content string

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ function isTodoItem(tokens, index) {
 function todoify(token, TokenConstructor) {
 	token.children.unshift(makeCheckbox(token, TokenConstructor));
 	token.children[1].content = token.children[1].content.slice(3);
-	token.content = token.content.slice(3);
+	token.content = token.content.slice(4);
 
 	if (useLabelWrapper) {
 		if (useLabelAfter) {


### PR DESCRIPTION
This addresses an issue we've found where the content of the task list item includes the space between the label text and the checkbox itself. Doing multiple back-and-forth castings from HTML to markdown keeps adding a space at the start of an item because of this.

https://community.openproject.org/projects/openproject/work_packages/42050/activity?query_id=3006