### PR TITLE
git commit -m "fix: remove extra leading space in task list items"

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,8 +56,8 @@ function isTodoItem(tokens, index) {
 
 function todoify(token, TokenConstructor) {
 	token.children.unshift(makeCheckbox(token, TokenConstructor));
-	token.children[1].content = token.children[1].content.slice(3);
-	token.content = token.content.slice(3);
+	token.children[1].content = token.children[1].content.slice(4);
+	token.content = token.content.slice(4);
 
 	if (useLabelWrapper) {
 		if (useLabelAfter) {


### PR DESCRIPTION
## Summary
This pull request fixes an extra space at the beginning of the task list item text.

## Before & After
**Before**
The rendered HTML contains a space between `">` and the text:

```html
<li class="task-list-item">
  <label>
    <input class="task-list-item-checkbox" checked="" disabled="" type="checkbox"> list item
  </label>
</li>
```

**After**
The extra space is removed:

```html
<li class="task-list-item">
  <label>
    <input class="task-list-item-checkbox" checked="" disabled="" type="checkbox">list item
  </label>
</li>
```

Now the text directly follows the checkbox without any leading space, and the strikethrough style aligns correctly.

## Related
This issue was originally discovered when using text-decoration: line-through on task list items – the line extended one character too far to the left because of the extra space.
